### PR TITLE
fix: generate syncthing config in the correct path

### DIFF
--- a/bin/service-on
+++ b/bin/service-on
@@ -39,7 +39,7 @@ main() {
     if [ ! -f "$USERDATA_PATH/Syncthing/config/config.xml" ]; then
         echo "Generating configuration for Syncthing"
         mkdir -p "$USERDATA_PATH/Syncthing/config"
-        "$bindir/$bin_name" generate --no-default-folder --gui-user="minui" --gui-password="minui" "--home=$USERDATA_PATH/syncthing/config/" >"$LOGS_PATH/$PAK_NAME.generate.txt" 2>&1 &
+        "$bindir/$bin_name" generate --no-default-folder --gui-user="minui" --gui-password="minui" "--home=$USERDATA_PATH/Syncthing/config/" >"$LOGS_PATH/$PAK_NAME.generate.txt" 2>&1 &
 
         while is_service_running; do
             sleep 1


### PR DESCRIPTION
The generated path is lowercase but the in-use path is uppercase